### PR TITLE
Allow Safari 6.1 to use final Flexbox spec

### DIFF
--- a/data/prefixes.coffee
+++ b/data/prefixes.coffee
@@ -130,7 +130,8 @@ feature require('caniuse-db/features-json/user-select-none'), (browsers) ->
 # Flexible Box Layout
 feature require('caniuse-db/features-json/flexbox'), (browsers) ->
   browsers = map browsers, (browser, name, version) ->
-    if (name == 'safari' or name == 'ios_saf') and version < 7
+    if name == 'safari' and version < 6.1 or
+       name == 'ios_saf' and version < 7
       browser + ' 2009'
     else if name == 'chrome' and version < 21
       browser + ' 2009'


### PR DESCRIPTION
Safari 6.1 supports the final (prefixed) Flexbox spec as well as the 2009 spec. This pull request allows autoprefixer to prefer the latest spec for this version of Desktop Safari.
