### PR TITLE
multiline comments should not be removed when specified within css calc()

### DIFF
--- a/test/cases/comments.css
+++ b/test/cases/comments.css
@@ -1,6 +1,7 @@
 a {
     /* transition */
     transition: all 1s;
+    height: calc(/* comment before */100% - /* comment inside */ 10px/* comment after */);
 }
 
 /* placeholder */

--- a/test/cases/comments.out.css
+++ b/test/cases/comments.out.css
@@ -3,6 +3,8 @@ a {
     -webkit-transition: all 1s;
          -o-transition: all 1s;
             transition: all 1s;
+    height: -webkit-calc(/* comment before */100% - /* comment inside */ 10px/* comment after */);
+    height: calc(/* comment before */100% - /* comment inside */ 10px/* comment after */);
 }
 
 /* placeholder */


### PR DESCRIPTION
Added a failing test - multiline comments should not be removed when specified within css calc().

/CC @noomorph 
