### PR TITLE
Use specific version constraint for "caniuse"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "coffee-script": "1.8.0",
-        "caniuse-db":    "^1.0.30000040",
+        "caniuse-db":    "1.0.30000040",
         "postcss":       "~3.0.7"
     },
     "devDependencies": {


### PR DESCRIPTION
I would expect `autoprefixer-core` in a certain patch version (like 4.0.2) to always install the same version of *caniuse* data. Currently that's not the case due to the *caret* dependency operator.
A autoprefixer-core 4.0.2 installation could use caniuse 1.0.30000040, but also the newer 1.0.30000043 (or any newer version < 2.0 for that matter).

I understand the "caniuse" dependency is updated manually from time to time. In that case I think it would make more sense to update *caniuse* data specifically to one version to have reproducable results.

Wdyt?

cc @christopheschwyzer