### PR TITLE
Add ::placeholder-shown support

### DIFF
--- a/data/prefixes.coffee
+++ b/data/prefixes.coffee
@@ -185,7 +185,7 @@ feature require('caniuse-db/features-json/css-placeholder'), (browsers) ->
     [name, version] = i.split(' ')
     if name == 'firefox' and parseFloat(version) <= 18 then i + ' old' else i
 
-  prefix '::placeholder',
+  prefix '::placeholder-shown', '::placeholder',
           selector: true,
           browsers: browsers
 

--- a/lib/hacks/placeholder.coffee
+++ b/lib/hacks/placeholder.coffee
@@ -1,7 +1,7 @@
 Selector = require('../selector')
 
 class Placeholder extends Selector
-  @names = ['::placeholder']
+  @names = ['::placeholder-shown', '::placeholder']
 
   # Add old mozilla to possible prefixes
   possible: ->

--- a/test/cases/placeholder.css
+++ b/test/cases/placeholder.css
@@ -1,3 +1,6 @@
 ::placeholder {
     color: #999
 }
+::placeholder-shown {
+    color: #999
+}

--- a/test/cases/placeholder.out.css
+++ b/test/cases/placeholder.out.css
@@ -13,3 +13,18 @@
 ::placeholder {
     color: #999
 }
+::-webkit-input-placeholder {
+    color: #999
+}
+:-moz-placeholder {
+    color: #999
+}
+::-moz-placeholder {
+    color: #999
+}
+:-ms-input-placeholder {
+    color: #999
+}
+::placeholder-shown {
+    color: #999
+}


### PR DESCRIPTION
The `::placeholder-shown` is the pseudo-element defined in [spec](http://www.w3.org/TR/selectors4/#placeholder) and use by [caniuse](http://caniuse.com/#feat=css-placeholder). `::placeholder` no longer exists. But, the PR keeps `::placeholder` for compatibility issue for now. If you merge it only for next major release of autoprefixer, maybe you can remove `::placeholder`.