### PR TITLE
DynJS compatibility

### DIFF
--- a/data/prefixes.coffee
+++ b/data/prefixes.coffee
@@ -8,7 +8,13 @@ sort = (array) ->
     else if a[0] < b[0]
       -1
     else
-      parseFloat(a[1]) - parseFloat(b[1])
+      d = parseFloat(a[1]) - parseFloat(b[1])
+      if d > 0
+        1
+      else if d < 0
+        -1
+      else
+        0
 
 # Convert Can I Use data
 feature = (data, opts, callback) ->


### PR DESCRIPTION
DynJS (dynjs.org) is a JVM-based ECMAscript engine, which currently fails to run this module as it expects array sort functions to always return integer values, not floats. This minor change will still work with other more lenient engines but allows autoprefixer to run in DynJS, which in turn allows this module to work in Nodyn (http://nodyn.io/).