### PR TITLE
Fix issue occuring when '_autoprefixerDisabled' is undefined

### DIFF
--- a/lib/processor.coffee
+++ b/lib/processor.coffee
@@ -122,8 +122,12 @@ class Processor
       else
         false
 
-    else
+    else if node.parent
       node._autoprefixerDisabled = @disabled(node.parent)
+
+    else
+      # unknown state
+      false
 
   # Normalize spaces in cascade declaration group
   reduceSpaces: (decl) ->


### PR DESCRIPTION
This error is thrown when `node` doesn't have the property of `_autoprefixerDisabled`:
[TypeError: Cannot read property '_autoprefixerDisabled' of undefined]

ref: https://github.com/css-modules/css-modulesify/pull/13 &
https://github.com/css-modules/css-modulesify/pull/13#issuecomment-113040088